### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -46,6 +46,10 @@ const siteConfig = {
     // Highlight.js theme to use for syntax highlighting in code blocks
     theme: "atelier-savanna-dark"
   },
+  algolia: {
+    apiKey: '4a1af46ccc9139ac7f5600a41a29cdf7',
+    indexName: 'f8app',
+  },
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.